### PR TITLE
Update config.yaml for card-mod 3.4 update

### DIFF
--- a/Home Assistant Floorplan/config.yaml
+++ b/Home Assistant Floorplan/config.yaml
@@ -65,13 +65,14 @@ views:
       # Floorplan
       #################################################
       - type: 'custom:floorplan-card'
-        style: >
-          ha-card {
-              max-width: 150vh;
-              margin: 0 auto;
-              background: none;
-              box-shadow: none;
-          }
+        card_mod:
+          style: >
+            ha-card {
+                max-width: 150vh;
+                margin: 0 auto;
+                background: none;
+                box-shadow: none;
+            }
         config:
           image: '/local/floorplan_tutorial/floorplan_optimised.svg'
           stylesheet: '/local/floorplan_tutorial/floorplan.css'


### PR DESCRIPTION
Card-mod version 3.4 depreciated an old way to add CSS styles. Having card_mod: above style is now mandatory so this fixes that. More info here on that update here: https://github.com/thomasloven/lovelace-card-mod/issues/332